### PR TITLE
Fix typos and translations in README.md and README-en.md

### DIFF
--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -5,17 +5,17 @@
 
 Android device root solution based on [KernelSU](https://github.com/KernelSU/KernelSU)
 
-**Experimental! Use at your own risk! **This solution is based on [KernelSU]() and is experimental!
+**Experimental! Use at your own risk!** This solution is based on [KernelSU](https://github.com/KernelSU/KernelSU) and is experimental!
 
 >
-> This is an unofficial fork, all rights reserved [@tiann](https://github.com/tiann)
+> This is an unofficial fork. All rights are reserved to [@tiann](https://github.com/tiann)
 >
 
 - Fully adapted for non-GKI devices (susfs-dev and unsusfs-patched dev branches only)
 
 ## How to add
 
-Using the susfs-stable or susfs-dev branch (integrated susfs with support for non-GKI devices)
+Use the susfs-stable or susfs-dev branch (integrated susfs with support for non-GKI devices)
 
 ```
 curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setup.sh" | bash -s susfs-stable
@@ -25,12 +25,12 @@ curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setu
 curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setup.sh" | bash -s susfs-dev
 ```
 
-Use main branching
+Use the main branch
 ```
 curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setup.sh" | bash -s main
 ```
 
-Use dev branching（With support for non-GKI devices）
+Use dev branch（With support for non-GKI devices）
 ```
 curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setup.sh" | bash -s dev
 ```
@@ -38,7 +38,7 @@ curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setu
 ## How to use integrated susfs
 
 1. Use the susfs-dev branch directly without any patching
-2. Manually patch susfs using a dev branch that supports non-GKI devices.
+2. Manually patch susfs using the dev branch that supports non-GKI devices.
 
 
 ## More links
@@ -47,14 +47,14 @@ Projects compiled based on Sukisu and susfs
 - [OnePlus](https://github.com/ShirkNeko/Action_OnePlus_MKSU_SUSFS)
 
 ## Hook method
-- This method references the hook manual to (https://github.com/rsuntk/KernelSU)
+- This method references the hook method from (https://github.com/rsuntk/KernelSU)
 
 1. **KPROBES hook:**
-    - This fork only supports GKI (5.10 - 6.x) kernels, all non-GKI kernels must use manual hooks.
+    - This method only supports GKI (5.10 - 6.x) kernels, and all non-GKI kernels must use manual hooks.
     - For Loadable Kernel Modules (LKM)
     - Default hooking method for GKI kernels
-    - Requires `CONFIG_KPROBES=y`. 2.
-2. **Hooks manual:**
+    - Requires `CONFIG_KPROBES=y`.
+2. **Manual hooks:**
     - For GKI (5.10 - 6.x) kernels, add `CONFIG_KSU_MANUAL_HOOK=y` to the kernel defconfig and make sure to protect KernelSU hooks by using `#ifdef CONFIG_KSU_MANUAL_HOOK` instead of `#ifdef CONFIG_KSU`.
     - Standard KernelSU hooks: https://kernelsu.org/guide/how-to-integrate-for-non-gki.html#manually-modify-the-kernel-source
     - backslashxx syscall hooks: https://github.com/backslashxx/KernelSU/issues/5
@@ -63,23 +63,23 @@ Projects compiled based on Sukisu and susfs
 
 ## Usage
 [GKI]
-1. such as millet redmi samsung and other devices (does not include the magic kernel manufacturers such as: meizu, a plus real me oppo)
-2. find more links in the GKI build project to find the device kernel version directly download with TWRP or kernel flashing tool to brush into the zip with AnyKernel3 suffix can be
-3. General without the suffix of the .zip compressed package is universal, gz suffix for the special TianGui models, lz4 suffix for Google models, general brush without the suffix can be!
+1. such as Xiaomi, Redmi, Samsung, and other devices (does not include manufacturers that modified the kernel like Meizu, OnePlus, RealMe, and OPPO)
+2. Use the prebuilt GKI kernel, the ones with their name ending with AnyKernel3, mentioned in the 'More Links' section, and then flash it with recoveries like TWRP
+3. Generally, packages with a plain .zip suffix are universal. However, if your device has a MediaTek processor, you should use the ones with .gz suffix, and packages with .lz4 suffix are dedicated to Google devices.
 
 [OnePlus]
-1. Find the Yiga project in the More link and fill in your own, then build it with cloud compilation, and finally brush in the zip with AnyKernel3 suffix.
-Note: You only need to fill in the first two kernel versions, such as 5.10, 5.15, 6.1, 6.6.
+1. Use the link mentioned in the 'More Links' section to create a customized build with your device information, and then flash the zip file with the AnyKernel3 suffix.
+Note: You only need to fill in the first two parts of kernel versions, such as 5.10, 5.15, 6.1, or 6.6.
 - Please search for the processor codename by yourself, usually it is all English without numbers.
-- Branching and configuration files, please fill in the kernel open source address.
+- You can find the branch and configuration files from the OnePlus open-source kernel repository.
 
 
 
 ## Features
 
 1. Kernel-based `su` and root access management.
-2. Not based on [OverlayFS](https://en.wikipedia.org/wiki/OverlayFS) module system. 3.
-3. [Application Profiles](https://kernelsu.org/guide/app-profile.html): Lock root privileges in a cage. 4.
+2. Not based on [OverlayFS](https://en.wikipedia.org/wiki/OverlayFS) module system, but using [Magic Mount](https://github.com/KernelSU/KernelSU)
+3. [App Profile](https://kernelsu.org/guide/app-profile.html): Lock root privileges in a cage. 
 4. Bringing back non-GKI/GKI 1.0 support
 5. More customization
 
@@ -87,8 +87,8 @@ Note: You only need to fill in the first two kernel versions, such as 5.10, 5.15
 
 ## License
 
-- The file in the “kernel” directory is [GPL-2.0-only](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
-- All other parts except the “kernel” directory are [GPL-3.0 or later](https://www.gnu.org/licenses/gpl-3.0.html).
+- The file in the “kernel” directory is under [GPL-2.0-only](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) license.
+- All other parts except the “kernel” directory are under [GPL-3.0 or later](https://www.gnu.org/licenses/gpl-3.0.html) license.
 
 ## Sponsorship list
 - [Ktouls](https://github.com/Ktouls) Thanks so much for bringing me support
@@ -99,15 +99,15 @@ Note: You only need to fill in the first two kernel versions, such as 5.10, 5.15
 
 
 
-How the above list does not have your name, I will keep you updated, thanks again for your support!
+If the above list does not have your name, I will update it as soon as possible, and thanks again for your support!
 
 ## Contributions
 
 - [KernelSU](https://github.com/tiann/KernelSU): original project
 - [MKSU](https://github.com/5ec1cff/KernelSU): Used project
-- [RKSU](https://github.com/rsuntk/KernelsU)：Re-support of non-GKI devices using the kernel of this project
+- [RKSU](https://github.com/rsuntk/KernelsU): Reintroduced the support of non-GKI devices using the kernel of this project
 - [susfs](https://gitlab.com/simonpunk/susfs4ksu)：Used susfs file system
 - [KernelSU](https://git.zx2c4.com/kernel-assisted-superuser/about/): KernelSU conceptualization
 - [Magisk](https://github.com/topjohnwu/Magisk): Powerful root utility
 - [genuine](https://github.com/brevent/genuine/): APK v2 Signature Verification
-- [Diamorphine](https://github.com/m0nad/Diamorphine): Some rootkit skills.
+- [Diamorphine](https://github.com/m0nad/Diamorphine): Some rootkit utilities.

--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -3,9 +3,9 @@
 **Enlish** | [简体中文](README.md)
 
 
-Android device root solution based on [KernelSU](https://github.com/KernelSU/KernelSU)
+Android device root solution based on [KernelSU](https://github.com/tiann/KernelSU)
 
-**Experimental! Use at your own risk!** This solution is based on [KernelSU](https://github.com/KernelSU/KernelSU) and is experimental!
+**Experimental! Use at your own risk!** This solution is based on [KernelSU](https://github.com/tiann/KernelSU) and is experimental!
 
 >
 > This is an unofficial fork. All rights are reserved to [@tiann](https://github.com/tiann)
@@ -78,7 +78,7 @@ Note: You only need to fill in the first two parts of kernel versions, such as 5
 ## Features
 
 1. Kernel-based `su` and root access management.
-2. Not based on [OverlayFS](https://en.wikipedia.org/wiki/OverlayFS) module system, but using [Magic Mount](https://github.com/KernelSU/KernelSU)
+2. Not based on [OverlayFS](https://en.wikipedia.org/wiki/OverlayFS) module system, but based on [Magic Mount](https://github.com/5ec1cff/KernelSU) from 5ec1cff
 3. [App Profile](https://kernelsu.org/guide/app-profile.html): Lock root privileges in a cage. 
 4. Bringing back non-GKI/GKI 1.0 support
 5. More customization

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 基于 [KernelSU](https://github.com/tiann/KernelSU) 的安卓设备 root 解决方案
 
-**实验性!使用风险自负!**
+**实验性! 使用风险自负!**
 
 
 >
@@ -31,28 +31,28 @@ curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setu
 ```
 
 
-使用 dev 分支（带非GKI设备的支持）
+使用 dev 分支 (带非GKI设备的支持)
 ```
 curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setup.sh" | bash -s dev
 ```
 ## 如何集成 susfs
 
 1. 直接使用 susfs-stable 或者 susfs-dev 分支，不需要再集成 susfs
-2. 使用支持非GKI设备的 dev 分支,手动补丁 susfs
+2. 使用支持非GKI设备的 dev 分支, 手动补丁 susfs
 
 ## 钩子方法
 - 此部分引用自 [rsuntk 的钩子方法](https://github.com/rsuntk/KernelSU)
 
 1. **KPROBES 钩子：**
-    - 此方法仅支持 GKI 2.0（5.10 - 6.x）内核,所有非 GKI 2.0 内核都必须使用手动钩子
+    - 此方法仅支持 GKI 2.0 (5.10 - 6.x) 内核, 所有非 GKI 2.0 内核都必须使用手动钩子
     - 用于可加载内核模块 (LKM)
     - GKI 2.0 内核的默认钩子方法
     - 需要 `CONFIG_KPROBES=y`
 2. **手动钩子：**
-    - 对于 GKI 2.0（5.10 - 6.x）内核，需要在对应设备的 defconfig 文件中添加 `CONFIG_KSU_MANUAL_HOOK=y` 并确保使用 `#ifdef CONFIG_KSU_MANUAL_HOOK` 而不是 `#ifdef CONFIG_KSU` 来保护 KernelSU 钩子
+    - 对于 GKI 2.0 (5.10 - 6.x) 内核，需要在对应设备的 defconfig 文件中添加 `CONFIG_KSU_MANUAL_HOOK=y` 并确保使用 `#ifdef CONFIG_KSU_MANUAL_HOOK` 而不是 `#ifdef CONFIG_KSU` 来保护 KernelSU 钩子
     - 标准的 KernelSU 钩子：https://kernelsu.org/guide/how-to-integrate-for-non-gki.html#manually-modify-the-kernel-source
     - backslashxx 的 syscall 手动钩子：https://github.com/backslashxx/KernelSU/issues/5
-    - 部分手动集成KPROBES的非 GKI 2.0 设备不需要手动 VFS 钩子 `new_hook.patch` 补丁
+    - 部分手动集成 KPROBES 的非 GKI 2.0 设备不需要手动 VFS 钩子 `new_hook.patch` 补丁
 
 
 ## 更多链接
@@ -64,7 +64,7 @@ curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setu
 ## 使用方法
 
 ### GKI
-1. 适用于如小米红米三星等的 GKI 2.0 的设备（不包含魔改内核的厂商如魅族、一加、真我和 oppo）
+1. 适用于如小米红米三星等的 GKI 2.0 的设备 (不包含魔改内核的厂商如魅族、一加、真我和 oppo)
 2. 找到更多链接里的 GKI 构建的项目找到设备内核版本直接下载用TWRP或者内核刷写工具刷入带 AnyKernel3 后缀的压缩包即可
 3. 一般不带后缀的 .zip 压缩包是通用，gz 后缀的为天玑机型专用，lz4 后缀的为谷歌系机型专用，一般刷不带后缀的即可
 
@@ -100,7 +100,7 @@ curl -LSs "https://raw.githubusercontent.com/ShirkNeko/KernelSU/main/kernel/setu
 
 
 
-如何以上名单没有你的名称，我会及时更新，再次感谢大家的支持
+如果以上名单没有你的名称，我会及时更新，再次感谢大家的支持
 
 ## 贡献
 


### PR DESCRIPTION
- README.md
  + Unified brackets use to '(' and ')'.
  + Added some missing spaces between English words.
  + Fixed typos.
- README-en.md
  + Fixed various translation errors.
  + Fixed various grammar errors.